### PR TITLE
Remove use of DefaultAzureCredential in prod

### DIFF
--- a/src/Logic/AzureStorage/CredentialUtility.cs
+++ b/src/Logic/AzureStorage/CredentialUtility.cs
@@ -1,0 +1,17 @@
+using Azure.Identity;
+using Azure.Core;
+
+namespace NuGet.Insights
+{
+    public static class CredentialUtility
+    {
+        public static TokenCredential GetDefaultAzureCredential()
+        {
+#if DEBUG
+            return new DefaultAzureCredential();
+#else
+            throw new NotSupportedException("DefaultAzureCredential is not supported in production. Use a different credential type.");
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Not sure if we're using ClientCertificateCredentials in practice but I'm not sure I understand the flow since getting the certificate from a key vault currently requires `DefautlAzureCredential`. I'm not sure why you wouldn't just skip the step so let me know if I'm misunderstanding.

Addresses https://github.com/NuGet/Engineering/issues/5869